### PR TITLE
refs #304 - Default value enable

### DIFF
--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -32,6 +32,12 @@ static const char *default_config = QUOTE({
 				"default" : PLUGIN_NAME,
 				"readonly" : "true"
 			},
+            "enable": {
+                "description": "A switch that can be used to enable or disable execution of the filter.",
+                "displayName": "Enabled",
+                "type": "boolean",
+                "default": "true"
+            },
             "exchanged_data": {
                     "description" : "exchanged data list",
                     "type" : "JSON",


### PR DESCRIPTION
Added the default value for the enable parameter. This allows services using the plugin to be displayed correctly in fledge-ui.