### PR TITLE
Fix signed-integer overflow (UB) in PivotTimestamp seconds decode

### DIFF
--- a/include/iec104_pivot_object.hpp
+++ b/include/iec104_pivot_object.hpp
@@ -38,7 +38,7 @@ public:
 
     void setTimeInMs(long ms);
 
-    int SecondSinceEpoch();
+    uint32_t SecondSinceEpoch();
     int FractionOfSecond();
     uint64_t getTimeInMs();
 

--- a/src/iec104_pivot_object.cpp
+++ b/src/iec104_pivot_object.cpp
@@ -180,10 +180,14 @@ uint64_t
 PivotTimestamp::getTimeInMs(){
     uint32_t timeval32;
 
-    timeval32 = m_valueArray[3];
-    timeval32 += m_valueArray[2] * 0x100;
-    timeval32 += m_valueArray[1] * 0x10000;
-    timeval32 += m_valueArray[0] * 0x1000000;
+    // Reconstruct seconds in unsigned 32-bit arithmetic. The previous form
+    // `m_valueArray[0] * 0x1000000` promoted uint8_t to int and multiplied by an
+    // int literal, which is signed-overflow UB once the top byte is >= 128
+    // (SecondSinceEpoch >= 2^31, i.e. 2038+).
+    timeval32  =  (uint32_t) m_valueArray[3];
+    timeval32 |= ((uint32_t) m_valueArray[2]) << 8;
+    timeval32 |= ((uint32_t) m_valueArray[1]) << 16;
+    timeval32 |= ((uint32_t) m_valueArray[0]) << 24;
 
     uint32_t fractionOfSecond = 0;
 
@@ -209,14 +213,16 @@ PivotTimestamp::FractionOfSecond(){
     return fractionOfSecond;
 }
 
-int
+uint32_t
 PivotTimestamp::SecondSinceEpoch(){
-    int32_t timeval32;
+    uint32_t timeval32;
 
-    timeval32 = m_valueArray[3];
-    timeval32 += m_valueArray[2] * 0x100;
-    timeval32 += m_valueArray[1] * 0x10000;
-    timeval32 += m_valueArray[0] * 0x1000000;
+    // Unsigned 32-bit reconstruction (see getTimeInMs): the signed form overflowed
+    // (UB) for the top byte >= 128, and an int return cannot represent seconds >= 2^31.
+    timeval32  =  (uint32_t) m_valueArray[3];
+    timeval32 |= ((uint32_t) m_valueArray[2]) << 8;
+    timeval32 |= ((uint32_t) m_valueArray[1]) << 16;
+    timeval32 |= ((uint32_t) m_valueArray[0]) << 24;
 
     return timeval32;
 }
@@ -260,7 +266,7 @@ PivotTimestamp::handleTimeQuality(Datapoint* timeQuality)
 PivotTimestamp::PivotTimestamp(Datapoint* timestampData)
 {
     DatapointValue& dpv = timestampData->getData();
-    m_valueArray = new uint8_t[7];
+    m_valueArray = new uint8_t[7]();  // zero-init: guards getTimeInMs() when `t` is present but not a dict
 
     if (dpv.getType() == DatapointValue::T_DP_DICT)
     {
@@ -292,7 +298,7 @@ PivotTimestamp::PivotTimestamp(Datapoint* timestampData)
 
 PivotTimestamp::PivotTimestamp(long ms)
 {
-    m_valueArray = new uint8_t[7];
+    m_valueArray = new uint8_t[7]();  // zero-init: guards getTimeInMs() when `t` is present but not a dict
     uint32_t timeval32 = (uint32_t) (ms/ 1000LL);
 
     m_valueArray[0] = (timeval32 / 0x1000000 & 0xff);

--- a/tests/test_pivot_timestamp_overflow.cpp
+++ b/tests/test_pivot_timestamp_overflow.cpp
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+
+#include <datapoint.h>
+#include <iec104_pivot_object.hpp>
+#include <iec104_pivot_filter_config.hpp>
+
+#include <string>
+#include <vector>
+
+// Regression test for the signed-integer-overflow (UB) in PivotTimestamp seconds decoding.
+//
+// Before the fix, `getTimeInMs()` and `SecondSinceEpoch()` reconstructed the 32-bit seconds with
+// `m_valueArray[0] * 0x1000000` (uint8_t promoted to int, multiplied by an int literal). For any
+// timestamp whose top byte is >= 128 (SecondSinceEpoch >= 2^31, i.e. 2038-01-19 onward) this is
+// signed-integer overflow (undefined behaviour) and yields a wrong/truncated `do_ts`.
+//
+// This drives the public path PivotDataObject builder -> toIec104DataObject(), which is what the
+// n104 pipeline uses, and asserts the emitted `do_ts` round-trips exactly.
+
+namespace {
+
+Datapoint* findChild(Datapoint* dictDp, const std::string& name)
+{
+    if (!dictDp) return nullptr;
+    DatapointValue& v = dictDp->getData();
+    if (v.getType() != DatapointValue::T_DP_DICT) return nullptr;
+    std::vector<Datapoint*>* vec = v.getDpVec();
+    if (!vec) return nullptr;
+    for (Datapoint* d : *vec) {
+        if (d->getName() == name) return d;
+    }
+    return nullptr;
+}
+
+} // namespace
+
+// SecondSinceEpoch >= 2^31 (3e9 s) must not overflow and must round-trip exactly through do_ts.
+TEST(PivotTimestampOverflow, SecondsBeyond2038RoundTripExact)
+{
+    const long long ms = 3000000000000LL; // 3e9 seconds -> top byte 178 (>= 128)
+
+    PivotDataObject pivot("GTIM", "MvTyp");
+    pivot.setIdentifier("PID-1");
+    pivot.setCause(3); // spontaneous
+    pivot.setMagF(1.0f);
+    pivot.addTimestamp(static_cast<long>(ms), false, false, false);
+
+    Datapoint* builtPivot = pivot.toDatapoint();
+    ASSERT_NE(builtPivot, nullptr);
+
+    IEC104PivotDataPoint exchangeConfig("LABEL-1", "PID-1", "MvTyp", "M_ME_NC_1", 1, 1, "");
+    PivotDataObject parsed(builtPivot);
+    Datapoint* dataObject = parsed.toIec104DataObject(&exchangeConfig);
+    ASSERT_NE(dataObject, nullptr);
+
+    Datapoint* doTs = findChild(dataObject, "do_ts");
+    ASSERT_NE(doTs, nullptr);
+    EXPECT_EQ(static_cast<long long>(doTs->getData().toInt()), ms);
+}
+
+// Direct check of the decoder for a full 32-bit seconds value (no overflow, no truncation).
+TEST(PivotTimestampOverflow, DecoderUnsignedSeconds)
+{
+    PivotTimestamp ts(3000000000000LL); // ms
+    EXPECT_EQ(static_cast<unsigned long>(ts.SecondSinceEpoch()), 3000000000UL);
+    EXPECT_EQ(static_cast<unsigned long long>(ts.getTimeInMs()), 3000000000000ULL);
+}


### PR DESCRIPTION
## Summary

`PivotTimestamp::getTimeInMs()` and `PivotTimestamp::SecondSinceEpoch()` reconstruct the 32-bit
"seconds since epoch" from the byte buffer with `m_valueArray[0] * 0x1000000`. `m_valueArray[0]` is
`uint8_t` (integer-promoted to `int`) and `0x1000000` is an `int` literal, so once the most-significant
byte is `>= 128` (i.e. `SecondSinceEpoch >= 2^31`, any time at/after **2038-01-19**) the product
`128 * 16777216 == 2^31` exceeds `INT_MAX` → **signed-integer overflow, which is undefined behaviour**.
`SecondSinceEpoch()` additionally returned `int`, which cannot represent seconds `>= 2^31`.

This is reachable from ordinary pipeline data via `toIec104DataObject()` whenever a pivot carries a
far-future (or, read through `uint32_t`, negative) `t.SecondSinceEpoch`. A related path: in
`PivotTimestamp(Datapoint*)` the buffer is allocated but **not** zero-initialised, so a `t` that is
present but not a `T_DP_DICT` leaves it uninitialised and `getTimeInMs()` then reads uninitialised
bytes (and overflows).

Found via fuzzing of `PivotDataObject(Datapoint*)` + `toIec104DataObject()` (the parser is otherwise
memory-safe — no UAF/OOB in ~350k iterations); reproduced under UBSan:

```
src/iec104_pivot_object.cpp:219:34: runtime error: signed integer overflow:
178 * 16777216 cannot be represented in type 'int'
```

## Fix

- Reconstruct the seconds in **unsigned 32-bit** arithmetic (`(uint32_t)byte << N`) in both
  `getTimeInMs()` and `SecondSinceEpoch()`.
- `SecondSinceEpoch()` now returns `uint32_t` (callers cast to `long`, unchanged).
- Zero-initialise `m_valueArray` (`new uint8_t[7]()`) so a non-dict `t` cannot cause an uninitialised
  read.

## Test

Adds `tests/test_pivot_timestamp_overflow.cpp` (auto-globbed by the existing test CMake). It exercises
a `2038+` timestamp (`SecondSinceEpoch = 3e9`) through both the decoder and the public
`toIec104DataObject()` path and asserts the emitted `do_ts` round-trips exactly (`3000000000000`),
which would previously overflow.

## Verification

Verified locally with `g++ -fsanitize=address,undefined -fno-sanitize-recover=all`: the minimal repro
above aborts on `main` and is clean after the fix, with `do_ts` and `SecondSinceEpoch` exact. (The full
GoogleTest suite needs the Fledge SDK + lib60870, which run in CI; the new case is verified equivalently
with a standalone UBSan harness.)

## Related

Touches the same `PivotTimestamp` decoding as #30, but is a **distinct** defect (signed overflow in the
**seconds** reconstruction, not the `FractionOfSecond`/`16777` question in #30). The fraction-constant
discussion in #30 is intentionally not changed here.
